### PR TITLE
fix typo in about section of index page

### DIFF
--- a/war/index.html
+++ b/war/index.html
@@ -136,7 +136,7 @@
             <ul>
                 <p>The Groovy Web Console is a website for sharing and executing Groovy programming snippets of code!</p>
                 <li>Application deployed on <a href="http://code.google.com/appengine">Google App Engine</a></li>
-                <li>Developed with the <a href="http://gaelyk.appspot.com">Gaelyk</a> lightweigh Groovy toolkit for Google App Engine</li>
+                <li>Developed with the <a href="http://gaelyk.appspot.com">Gaelyk</a> lightweight Groovy toolkit for Google App Engine</li>
                 <li>Programmed with <a href="http://groovy.codehaus.org">Groovy</a></li>
                 <li>Code hosted on <a href="http://github.com/glaforge/groovywebconsole/tree/master">GitHub</a> and managed with Git</li>
                 <li>Live syntax highlighting provided by <a href="http://marijn.haverbeke.nl/codemirror/">CodeMirror</a></li>


### PR DESCRIPTION
"a lightweigh" -> "a lightweight"
